### PR TITLE
Assert that LocalDate object parsed into a String is not null

### DIFF
--- a/src/main/java/duke/DateParser.java
+++ b/src/main/java/duke/DateParser.java
@@ -20,6 +20,7 @@ public class DateParser {
      * @return String corresponding to the <code>LocalDate</code>
      */
     public static String dateToString(LocalDate date) {
+        assert date != null: "LocalDate object is not initialized correctly.";
         return date.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG));
     }
 }


### PR DESCRIPTION
- DateParser::dateToString assumes that the LocalDate object is a valid LocalDate and attempts to parse it into a String

- However, passing in a null object as an argument for the function is possible and may lead to errors during the invoking of this function

- Adding an assertion to the start of this function ensures that the LocalDate object cannot be null